### PR TITLE
feat: insert yaml anchor after yaml doc separator (if it exists)

### DIFF
--- a/scripts/drivers/_custom.sh
+++ b/scripts/drivers/_custom.sh
@@ -78,6 +78,12 @@ driver_decrypt_file() {
         exit 1
     fi
 
+    # Insert the yaml anchor after the yaml document separator (if it exists)
+    if grep "\---" ${input_tmp} > /dev/null; then
+       _sed_i '1i\---' "${output_tmp}"
+       _sed_i 's/---//' "${input_tmp}"
+    fi
+
     if [ "${output}" = "" ]; then
         cat "${output_tmp}" "${input_tmp}"
     else


### PR DESCRIPTION
Hey 👋 me again 😜 

I'm currently trying the plugin with the vault driver and values files that contains yaml document separator at the beginning of the file ('---')
```
---
config:
  api_url: *helm-secret-kv_foo_BAR

```
It appears when decrypting the file that the anchors will not be inserted in the same yaml document as the rest of the fields (so separated by '---') Therefore it cannot be known when parsing the decrypted file by helm.
```
.helm-secret-kv_foo_BAR: &helm-secret-kv_foo_BAR mySecret

---
config:
  api_url: *helm-secret-kv_foo_BAR

```
The change here will detect when that separator is there and instead of putting the anchors at the beginning of the file it will put them just after the document separator
```
---
.helm-secret-kv_foo_BAR: &helm-secret-kv_foo_BAR mySecret

config:
  api_url: *helm-secret-kv_foo_BAR

```

Don't hesitate to ask me more details if needed

Cheers 😉 