### PR TITLE
Cleanup temporary files/dirs from tests.

### DIFF
--- a/tests/lib/helper.bash
+++ b/tests/lib/helper.bash
@@ -56,7 +56,8 @@ setup() {
     SEED="${RANDOM}"
 
     TEST_TEMP_DIR="$(TMPDIR="${W_TEMP:-/tmp/}" mktemp -d)"
-    HOME="$(mktemp -d)"
+    TEST_TEMP_HOME="$(mktemp -d)"
+    HOME="${TEST_TEMP_HOME}"
 
     # shellcheck disable=SC2034
     XDG_DATA_HOME="${HOME}"
@@ -132,6 +133,7 @@ teardown() {
     rm -rf "${TEST_TEMP_DIR}/home/.gnupg/"
 
     temp_del "${TEST_TEMP_DIR}"
+    temp_del "${TEST_TEMP_HOME}"
 }
 
 create_chart() {

--- a/tests/unit/dec.bats
+++ b/tests/unit/dec.bats
@@ -95,6 +95,8 @@ load '../bats/extensions/bats-file/load'
     assert_file_exist "${HELM_SECRETS_DEC_DIR}/secrets.yaml.dec"
     assert_file_contains "${HELM_SECRETS_DEC_DIR}/secrets.yaml.dec" 'global_secret: '
     assert_file_contains "${HELM_SECRETS_DEC_DIR}/secrets.yaml.dec" 'global_bar'
+
+    temp_del "${HELM_SECRETS_DEC_DIR}"
 }
 
 @test "dec: Decrypt secrets.yaml + http://" {

--- a/tests/unit/plugin-install.bats
+++ b/tests/unit/plugin-install.bats
@@ -6,7 +6,7 @@ load '../bats/extensions/bats-assert/load'
 load '../bats/extensions/bats-file/load'
 
 @test "plugin-install: helm plugin install" {
-    HOME="$(mktemp -d)"
+    HOME="$(mktemp -d "${TEST_TEMP_HOME}/tmp.XXXXXXXXXX")"
 
     # Windows
     # See: https://github.com/helm/helm/blob/b4f8312dbaf479e5f772cd17ae3768c7a7bb3832/pkg/helmpath/lazypath_windows.go#L22
@@ -15,13 +15,15 @@ load '../bats/extensions/bats-file/load'
 
     run helm plugin install "${GIT_ROOT}"
     assert_output --regexp "$(printf "sops is already installed: sops .*\nInstalled plugin: secrets")"
+
+    HOME="${TEST_TEMP_HOME}"
 }
 
 @test "plugin-install: SKIP_SOPS_INSTALL=true helm plugin install" {
     SKIP_SOPS_INSTALL=true
     export SKIP_SOPS_INSTALL
 
-    HOME="$(mktemp -d)"
+    HOME="$(mktemp -d "${TEST_TEMP_HOME}/tmp.XXXXXXXXXX")"
 
     # Windows
     # See: https://github.com/helm/helm/blob/b4f8312dbaf479e5f772cd17ae3768c7a7bb3832/pkg/helmpath/lazypath_windows.go#L22
@@ -30,6 +32,8 @@ load '../bats/extensions/bats-file/load'
 
     run helm plugin install "${GIT_ROOT}"
     assert_output --regexp "$(printf "Skipping sops installation.\nInstalled plugin: secrets")"
+
+    HOME="${TEST_TEMP_HOME}"
 }
 
 @test "plugin-install: helm plugin list" {


### PR DESCRIPTION
Tests leave a lot of tmp files/dirs when run, this diff leaves only tmpfiles leaked by plugin/drivers.

From `main` branch as of `be47fb3` + https://github.com/jkroepke/helm-secrets/pull/89 I found `lint.bats`, `template.bats` and `vault.bats` to leak 0-byte tmpfiles, not from the tests themselves.