### PR TITLE
Hotfix for #90.

### DIFF
--- a/tests/lib/helper.bash
+++ b/tests/lib/helper.bash
@@ -160,6 +160,9 @@ helm_plugin_install() {
             esac
 
             env APPDATA="${HELM_CACHE}/home/" HOME="${HELM_CACHE}/home/" helm plugin install "${URL}" ${VERSION:+--version ${VERSION}}
+
+            # prevent temp_del to block on write-protected git objects
+            chmod -R +w "${HELM_CACHE}/home/.cache/helm/" "${HELM_CACHE}/home/.local/share/helm/"
         fi
 
         cp -r "${HELM_CACHE}/home/." "${HOME}"


### PR DESCRIPTION
Git sets some files to read only, and `temp_del` use `rm -r --` which waits for user confirmation.

Set files to be writeable so `temp_del` does not block.

Did not catch this previously as I had a `.tmp` cache folder with correct permissions.