### PR TITLE
Cleanup temporary files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,10 +7,10 @@ insert_final_newline = true
 [*.cmd]
 end_of_line = crlf
 
-[*.{sh,bash,bats}]
+[*.{sh,bats,bash}]
 indent_style = space
 indent_size = 4
-max_line_length = 80
+max_line_length = 120
 trim_trailing_whitespace = true
 
 [*.sh]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Allow override sops version on installation
 ### Added
 - Detect ArgoCD environment by `ARGOCD_APP_NAME` environment variable and set `HELM_SECRETS_QUIET=true` by default. (https://github.com/jkroepke/helm-secrets/pull/83)
 
+### Fixes
+- Cleanup all temporary files.
+
 ## [3.5.0] - 2021-02-20
 
 ### Added

--- a/scripts/commands/helm.sh
+++ b/scripts/commands/helm.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-set -eufx
+set -euf
 
 # shellcheck disable=SC1090
 . "${SCRIPT_DIR}/commands/dec.sh"

--- a/scripts/commands/helm.sh
+++ b/scripts/commands/helm.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-set -euf
+set -eufx
 
 # shellcheck disable=SC1090
 . "${SCRIPT_DIR}/commands/dec.sh"

--- a/scripts/commands/helm.sh
+++ b/scripts/commands/helm.sh
@@ -24,7 +24,7 @@ Typical usage:
 EOF
 }
 
-decrypted_files=$(mktemp)
+decrypted_files=$(_mktemp)
 
 _trap_hook() {
     if [ -s "${decrypted_files}" ]; then

--- a/scripts/drivers/_custom.sh
+++ b/scripts/drivers/_custom.sh
@@ -29,8 +29,8 @@ driver_decrypt_file() {
     # if omit then output to stdout
     output="${3:-}"
 
-    output_yaml="$(mktemp)"
-    output_yaml_anchors="$(mktemp)"
+    output_yaml="$(_mktemp)"
+    output_yaml_anchors="$(_mktemp)"
 
     # Strip yaml separator
     sed -e '/^---$/d' "${input}" >"${output_yaml}"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -46,7 +46,7 @@ _regex_escape() {
 
 _trap() {
     # https://stackoverflow.com/a/85903/8087167
-    if LC_ALL=C type _trap_hook > /dev/null; then
+    if LC_ALL=C type _trap_hook >/dev/null; then
         _trap_hook
     fi
 

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -49,9 +49,9 @@ _trap_hook() {
 }
 
 _trap() {
-    rm -rf "${TMPDIR}"
-
     _trap_hook
+
+    rm -rf "${TMPDIR}"
 }
 
 if on_macos; then

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -45,7 +45,9 @@ _regex_escape() {
 }
 
 _trap() {
-    _trap_hook
+    if command -v _trap_hook >/dev/null; then
+        _trap_hook
+    fi
 
     rm -rf "${TMPDIR}"
 }

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -44,12 +44,11 @@ _regex_escape() {
     sed -e 's/[]\/()$*.^|[]/\\&/g'
 }
 
-_trap_hook() {
-    true
-}
-
 _trap() {
-    _trap_hook
+    # https://stackoverflow.com/a/85903/8087167
+    if LC_ALL=C type _trap_hook > /dev/null; then
+        _trap_hook
+    fi
 
     rm -rf "${TMPDIR}"
 }

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -45,10 +45,7 @@ _regex_escape() {
 }
 
 _trap() {
-    # https://stackoverflow.com/a/85903/8087167
-    if LC_ALL=C type "_trap_hook" >/dev/null; then
-        _trap_hook
-    fi
+    _trap_hook
 
     rm -rf "${TMPDIR}"
 }

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -55,7 +55,7 @@ _trap() {
 }
 
 if on_macos; then
-    _mktemp() { mktemp -t "${TMPDIR}/" "$@"; }
+    _mktemp() { mktemp -t "${TMPDIR_SUFFIX}/" "$@"; }
 else
     _mktemp() { mktemp "$@"; }
 fi

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -13,6 +13,10 @@ is_help() {
     esac
 }
 
+on_macos() {
+    [ "$(uname)" = "Darwin" ]
+}
+
 load_secret_driver() {
     driver="${1}"
     if [ -f "${SCRIPT_DIR}/drivers/${driver}.sh" ]; then
@@ -49,3 +53,9 @@ _trap() {
 
     _trap_hook
 }
+
+if on_macos; then
+    _mktemp() { mktemp -t "${TMPDIR}/" "$@"; }
+else
+    _mktemp() { mktemp "$@"; }
+fi

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -46,7 +46,7 @@ _regex_escape() {
 
 _trap() {
     # https://stackoverflow.com/a/85903/8087167
-    if LC_ALL=C type _trap_hook >/dev/null; then
+    if LC_ALL=C type "_trap_hook" >/dev/null; then
         _trap_hook
     fi
 

--- a/scripts/lib/file/custom.sh
+++ b/scripts/lib/file/custom.sh
@@ -7,7 +7,7 @@ _file_custom_exists() {
 }
 
 _file_custom_get() {
-    _tmp_file=$(mktemp)
+    _tmp_file=$(_mktemp)
 
     if ! helm template "${SCRIPT_DIR}/lib/file/helm-values-getter" -f "${1}" >"${_tmp_file}"; then
         exit 1

--- a/scripts/lib/file/http.sh
+++ b/scripts/lib/file/http.sh
@@ -7,7 +7,7 @@ _file_http_exists() {
 }
 
 _file_http_get() {
-    _tmp_file=$(mktemp)
+    _tmp_file=$(_mktemp)
     if ! download "${1}" >"${_tmp_file}"; then
         exit 1
     fi

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -9,8 +9,6 @@ fi
 # Path to current directory
 SCRIPT_DIR="$(dirname "$0")"
 
-_trap_hook() { true; }
-
 # shellcheck source=scripts/lib/common.sh
 . "${SCRIPT_DIR}/lib/common.sh"
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -18,9 +18,15 @@ SCRIPT_DIR="$(dirname "$0")"
 # shellcheck source=scripts/lib/http.sh
 . "${SCRIPT_DIR}/lib/http.sh"
 
-# Create temporary directory (not working on mac os, see: https://unix.stackexchange.com/a/555214)
+# Create a base temporary directory
 if on_macos; then
-    TMPDIR="$(basename "$(mktemp -d -t "${HELM_SECRETS_DEC_TMP_DIR:-"helm-secrets"}")")"
+    # on mac os TMPDIR does not work. see https://unix.stackexchange.com/a/555214)
+    # as workaround, we are going to create a base temporary directory inside the default directory and safe the
+    # generated directory name inside TMPDIR.
+    # The trap function late will care about this.
+    # shellcheck disable=SC2034
+    TMPDIR="$(mktemp -d -t "${HELM_SECRETS_DEC_TMP_DIR:-"helm-secrets"}")"
+    TMPDIR_SUFFIX="$(basename "${TMPDIR}")"
 else
     TMPDIR="${HELM_SECRETS_DEC_TMP_DIR:-$(mktemp -d)}"
 fi
@@ -37,7 +43,9 @@ SECRET_DRIVER_ARGS="${HELM_SECRETS_DRIVER_ARGS:-}"
 
 # The suffix to use for decrypted files. The default can be overridden using
 # the HELM_SECRETS_DEC_SUFFIX environment variable.
+# shellcheck disable=SC2034
 DEC_SUFFIX="${HELM_SECRETS_DEC_SUFFIX:-.yaml.dec}"
+# shellcheck disable=SC2034
 DEC_DIR="${HELM_SECRETS_DEC_DIR:-}"
 
 # Make sure HELM_BIN is set (normally by the helm command)

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-set -euf
+set -eufx
 
 if [ -n "${ARGOCD_APP_NAME+x}" ]; then
     HELM_SECRETS_QUIET="${HELM_SECRETS_QUIET:-true}"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-set -eufx
+set -euf
 
 if [ -n "${ARGOCD_APP_NAME+x}" ]; then
     HELM_SECRETS_QUIET="${HELM_SECRETS_QUIET:-true}"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -18,7 +18,7 @@ SCRIPT_DIR="$(dirname "$0")"
 # shellcheck source=scripts/lib/http.sh
 . "${SCRIPT_DIR}/lib/http.sh"
 
-# Create temporary directory (not working on mac os, see: https://unix.stackexchange.com/q/555058)
+# Create temporary directory (not working on mac os, see: https://unix.stackexchange.com/a/555214)
 if on_macos; then
     TMPDIR="$(basename "$(mktemp -d -t "${HELM_SECRETS_DEC_TMP_DIR:-"helm-secrets"}")")"
 else

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -9,6 +9,8 @@ fi
 # Path to current directory
 SCRIPT_DIR="$(dirname "$0")"
 
+_trap_hook() { true; }
+
 # shellcheck source=scripts/lib/common.sh
 . "${SCRIPT_DIR}/lib/common.sh"
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -27,8 +27,11 @@ if on_macos; then
     # shellcheck disable=SC2034
     TMPDIR="$(mktemp -d -t "${HELM_SECRETS_DEC_TMP_DIR:-"helm-secrets"}")"
     TMPDIR_SUFFIX="$(basename "${TMPDIR}")"
+elif [ -n "${HELM_SECRETS_DEC_TMP_DIR+x}" ]; then
+    mkdir -p "${HELM_SECRETS_DEC_TMP_DIR}"
+    TMPDIR="${HELM_SECRETS_DEC_TMP_DIR}"
 else
-    TMPDIR="${HELM_SECRETS_DEC_TMP_DIR:-$(mktemp -d)}"
+    TMPDIR="$(mktemp -d)"
 fi
 
 export TMPDIR

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -9,8 +9,23 @@ fi
 # Path to current directory
 SCRIPT_DIR="$(dirname "$0")"
 
-# Create temporary directory
-TMPDIR="${HELM_SECRETS_DEC_TMP_DIR:-$(mktemp -d)}"
+# shellcheck source=scripts/lib/common.sh
+. "${SCRIPT_DIR}/lib/common.sh"
+
+# shellcheck source=scripts/lib/file.sh
+. "${SCRIPT_DIR}/lib/file.sh"
+
+# shellcheck source=scripts/lib/http.sh
+. "${SCRIPT_DIR}/lib/http.sh"
+
+# Create temporary directory (not working on mac os, see: https://unix.stackexchange.com/q/555058)
+if on_macos; then
+    TMPDIR="$(basename "$(mktemp -d -t "${HELM_SECRETS_DEC_TMP_DIR:-"helm-secrets"}")")"
+else
+    TMPDIR="${HELM_SECRETS_DEC_TMP_DIR:-$(mktemp -d)}"
+fi
+
+export TMPDIR
 
 # Output debug infos
 QUIET="${HELM_SECRETS_QUIET:-false}"
@@ -27,15 +42,6 @@ DEC_DIR="${HELM_SECRETS_DEC_DIR:-}"
 
 # Make sure HELM_BIN is set (normally by the helm command)
 HELM_BIN="${HELM_BIN:-helm}"
-
-# shellcheck source=scripts/lib/common.sh
-. "${SCRIPT_DIR}/lib/common.sh"
-
-# shellcheck source=scripts/lib/file.sh
-. "${SCRIPT_DIR}/lib/file.sh"
-
-# shellcheck source=scripts/lib/http.sh
-. "${SCRIPT_DIR}/lib/http.sh"
 
 trap _trap EXIT
 

--- a/tests/unit/vault.bats
+++ b/tests/unit/vault.bats
@@ -32,7 +32,7 @@ load '../bats/extensions/bats-file/load'
     export HELM_SECRETS_DEC_TMP_DIR="helm-secrets.$$"
 
     # If non mac, prefix own tmp directory
-    # See: https://unix.stackexchange.com/q/555058
+    # See: https://unix.stackexchange.com/a/555214
     if [ "$(uname)" != "Darwin" ]; then
         export HELM_SECRETS_DEC_TMP_DIR="${TMPDIR:-/tmp}/${HELM_SECRETS_DEC_TMP_DIR}"
     fi

--- a/tests/unit/vault.bats
+++ b/tests/unit/vault.bats
@@ -23,3 +23,34 @@ load '../bats/extensions/bats-file/load'
     assert_output --partial "Error: plugin \"secrets\" exited with error"
     assert_file_not_exist "${FILE}.dec"
 }
+
+@test "vault: cleanup temporary files" {
+    if [ "${HELM_SECRETS_DRIVER}" != "vault" ]; then
+        skip
+    fi
+
+    export HELM_SECRETS_DEC_TMP_DIR="helm-secrets.$$"
+
+    # If non mac, prefix own tmp directory
+    # See: https://unix.stackexchange.com/q/555058
+    if [ "$(uname)" != "Darwin" ]; then
+        export HELM_SECRETS_DEC_TMP_DIR="${TMPDIR:-/tmp}/${HELM_SECRETS_DEC_TMP_DIR}"
+    fi
+
+    FILE="${TEST_TEMP_DIR}/values/${HELM_SECRETS_DRIVER}/secrets.yaml"
+
+    create_chart "${TEST_TEMP_DIR}"
+
+    run helm secrets template "${TEST_TEMP_DIR}/chart" -f "${FILE}" 2>&1
+    assert_success
+    assert_output --partial "[helm-secrets] Decrypt: ${FILE}"
+    assert_output --partial "port: 81"
+    assert_output --partial "[helm-secrets] Removed: ${FILE}.dec"
+    assert_file_not_exist "${FILE}.dec"
+
+    if [ "$(uname)" == "Darwin" ]; then
+        assert_dir_not_exist "${TMPDIR}${HELM_SECRETS_DEC_TMP_DIR}"
+    else
+        assert_dir_not_exist "${HELM_SECRETS_DEC_TMP_DIR}"
+    fi
+}


### PR DESCRIPTION
`TMPDIR` need to be exported, otherwise `mktemp` don't care.

On Mac OS, `TMPDIR` is not going to respect. The proposal is creating an own directory inside the fixed temp directory. 

See https://unix.stackexchange.com/q/555058 about the mac os specific behaivor

Closes #89 
Fixes #88 