### PR TITLE
Allow dot, asterisk and underscore for vault path

### DIFF
--- a/scripts/drivers/_custom.sh
+++ b/scripts/drivers/_custom.sh
@@ -43,7 +43,7 @@ driver_decrypt_file() {
         fi
 
         # generate yaml anchor name
-        YAML_ANCHOR=$(printf 'helm-secret-%s' "${_SECRET}" | tr '#$/' '_')
+        YAML_ANCHOR=$(printf 'helm-secret-%s' "${_SECRET}" | tr '#$/*.' '_')
 
         # Replace vault expression with yaml anchor
         EXPRESSION="$(echo "${EXPRESSION}" | _regex_escape)"

--- a/scripts/drivers/vault.sh
+++ b/scripts/drivers/vault.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 # shellcheck disable=SC2034
-_DRIVER_REGEX='!vault [A-z0-9][A-z0-9/\-]*\#[A-z0-9][A-z0-9-]*'
+_DRIVER_REGEX='!vault [A-z0-9][A-z0-9/*\.\_\-]*\#[A-z0-9*\.\_\-][A-z0-9*\.\_\-]*'
 
 # shellcheck source=scripts/drivers/_custom.sh
 . "${SCRIPT_DIR}/drivers/_custom.sh"

--- a/tests/assets/custom-driver.sh
+++ b/tests/assets/custom-driver.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 # shellcheck disable=SC2034
-_DRIVER_REGEX='!vault [A-z0-9][A-z0-9/\-]*\#[A-z0-9][A-z0-9-]*'
+_DRIVER_REGEX='!vault [A-z0-9][A-z0-9/*\.\_\-]*\#[A-z0-9*\.\_\-][A-z0-9*\.\_\-]*'
 
 . "${HELM_SECRETS_SCRIPT_DIR}/drivers/_custom.sh"
 

--- a/tests/assets/values/vault/secrets.yaml
+++ b/tests/assets/values/vault/secrets.yaml
@@ -3,3 +3,11 @@ key: !vault secret/gpg#key
 service:
   port: !vault secret/production#port
 data: !vault secret/production#data
+domain:
+  cert: !vault secret/domain#tls.crt
+  names:
+    - !vault secret/domain#*.test-example.com
+    - !vault secret/domain#example_com
+  keys:
+    - !vault secret/*.test-example.com#tls.key
+    - !vault secret/example_com#tls-2.key

--- a/tests/assets/values/vault/seed.sh
+++ b/tests/assets/values/vault/seed.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env sh
 
 vault kv put secret/production global_secret=global_bar port=81 port2=83
-vault kv put secret/domain tls.crt=tls.value
-vault kv put secret/domain *.test-example.com=key1
-vault kv put secret/domain example_com=key1
+vault kv put secret/domain tls.crt=tls.value *.test-example.com=key1 example_com=key1
 vault kv put secret/*.test-example.com tls.key=key2
 vault kv put secret/example_com tls-2.key=key2
 

--- a/tests/assets/values/vault/seed.sh
+++ b/tests/assets/values/vault/seed.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env sh
 
 vault kv put secret/production global_secret=global_bar port=81 port2=83
+vault kv put secret/domain tls.crt=tls.value
+vault kv put secret/domain *.test-example.com=key1
+vault kv put secret/domain example_com=key1
+vault kv put secret/*.test-example.com tls.key=key2
+vault kv put secret/example_com tls-2.key=key2
 
 vault kv put secret/gpg key="-----BEGIN PGP MESSAGE-----
 


### PR DESCRIPTION
allow path like:
secret/devops/certificates/internal.domain-with-hyphen.com#file.crt