### PR TITLE
translate env vars if found within file string

### DIFF
--- a/docs/ARGOCD.md
+++ b/docs/ARGOCD.md
@@ -64,7 +64,7 @@ ARG KUBECTL_VERSION="1.22.0"
 USER root
 RUN apt-get update && \
     apt-get install -y \
-      curl && \
+      curl gettext-base && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN curl -fSSL https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux \
@@ -309,6 +309,8 @@ spec:
         - secrets+gpg-import-kubernetes://argocd/helm-secrets-private-keys#key.asc?https://raw.githubusercontent.com/jkroepke/helm-secrets/main/tests/assets/values/sops/values.yaml
         # Using https://github.com/aslafy-z/helm-git
         - secrets+gpg-import-kubernetes://argocd/helm-secrets-private-keys#key.asc?git+https://github.com/jkroepke/helm-secrets@tests/assets/values/sops/secrets.yaml?ref=main"
+        # Fetching from a private repo with env variable
+        - secrets://https://$GITHUB_TOKEN@raw.githubusercontent.com/org/repo/ref/pathtofile.yml
 ```
 
 ## Known Issues

--- a/scripts/commands/view.sh
+++ b/scripts/commands/view.sh
@@ -15,7 +15,7 @@ EOF
 }
 
 view_helper() {
-    file="$1"
+    file=$(echo "${1}" | envsubst) # translate env vars supplied
 
     if ! _file_exists "$file"; then
         error 'File does not exist: %s\n' "${file}"


### PR DESCRIPTION
**What this PR does / why we need it**:
ArgoCD will pass in a values file that is escaped; this means that any env variables that may exist within the `argocd-repo-server` cannot be used. In our case, rather than adding the token in clear text to the values.yaml file (remote fetch), we can leverage an environment variable (such as `$GITHUB_TOKEN`) if it is already existing within that env

Example:
if you supply the string `secrets://https://$GITHUB_TOKEN@raw.githubusercontent.com/org/repo/ref/pathtofile.yml` to the Argo values files array and the secret `GITHUB_TOKEN` exists within the argocd-repo-server, it will be injected into the URL.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
