### PR TITLE
Fix broken json output on some systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Strip newlines on helm secrets terraform command
+
 ## [3.12.0] - 2022-02-03
 
 ### Added

--- a/scripts/commands/terraform.sh
+++ b/scripts/commands/terraform.sh
@@ -30,5 +30,5 @@ terraform() {
         exit 1
     fi
 
-    printf '{"content_base64":"%s"}' "$(printf '%s' "${content}" | base64)"
+    printf '{"content_base64":"%s"}' "$(printf '%s' "${content}" | base64 | tr -d \\n)"
 }

--- a/tests/unit/terraform.bats
+++ b/tests/unit/terraform.bats
@@ -11,8 +11,9 @@ load '../bats/extensions/bats-file/load'
 
     run helm secrets terraform "${FILE}"
     assert_success
-    assert_output --partial '{"content_base64":"'
-    assert_output --partial '"}'
+
+    # assert that there are no new lines in the base64
+    assert_output --regexp '\{"content_base64":"([A-Za-z0-9=]*)"\}'
 }
 
 @test "terraform: read invalid file" {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix broken json output on some systems

Running my TF on AWS CodeBuild image: `aws/codebuild/standard:5.0`

Typical usage:
  `$ helm secrets terraform secrets/myproject/nginx/secrets.yaml`

Would output: 
```json
{"content_base64":"<base64 coded content
 of value file>"}
```
(notice unexpected new line)

This is no longer a valid json.
This happens because `base64` on some platforms wraps output by default
ref: https://superuser.com/questions/1225134/why-does-the-base64-of-a-string-contain-n

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #193

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
