### PR TITLE
Remove aws_profile from encrypted file to be decrypted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added error handling in case `curl` or `wget` is not installed.
 - Added vals support on Windows
 - Enable protocol handling on Windows. Requires the command `helm secrets patch windows` once.
+- Added the replacement of `aws_profile: my_profile` with a blank string
 
 ### Changes
 - Check detection of sops encrypted files

--- a/scripts/drivers/sops.sh
+++ b/scripts/drivers/sops.sh
@@ -44,6 +44,9 @@ driver_decrypt_file() {
         input="$(_convert_path "${input}")"
     fi
 
+    # remove `aws_profile: my_profile` from the input file
+    perl -i -pe 's/aws_profile: (.*)//g' "$input"
+
     if [ "${output}" != "" ]; then
         if _sops_windows_path_required "${output}"; then
             output="$(_convert_path "${output}")"

--- a/scripts/drivers/sops.sh
+++ b/scripts/drivers/sops.sh
@@ -44,8 +44,15 @@ driver_decrypt_file() {
         input="$(_convert_path "${input}")"
     fi
 
+    OS="$(uname)"
+    if [ "$OS" = "Darwin" ]; then
+        FLAG="-i ''"
+    else
+        FLAG="-i''"
+    fi
+
     # remove `aws_profile: my_profile` from the input file
-    perl -i -pe 's/aws_profile: (.*)//g' "$input"
+    sed "$FLAG" -E 's/aws_profile: (.*)//g' "$input"
 
     if [ "${output}" != "" ]; then
         if _sops_windows_path_required "${output}"; then


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR modifies SOPS to replace `aws_profile: my_profile` with a blank string.
When using AWS KMS with several profiles, SOPS will add the field `aws_profile: my_profile` to the encrypted file, which will cause ArgoCD to fail when using **helm-secrets** to decrypt said file.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
