### PR TITLE
#249 add --sopsjson option to specify additional json files t decrypt…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- commandline flag --jsonsops <file.json> that uses sops to decrypte the file e.g. chart/files/config.json.
+  The decrypted file can then be imported into Secret or ConfigMap with Files.get file.json.dec
+
 ### Changed
 - Prefer bash from "Git for Windows" over "WSL" shell to avoid WSL interop incompatibilities
 

--- a/scripts/commands/dec.sh
+++ b/scripts/commands/dec.sh
@@ -21,6 +21,7 @@ EOF
 
 decrypt_helper() {
     encrypted_file_path="${1}"
+    encrypted_type="${2:-yaml}"
 
     if ! driver_is_file_encrypted "${encrypted_file_path}"; then
         return 1
@@ -28,7 +29,7 @@ decrypt_helper() {
 
     encrypted_file_dec="$(_file_dec_name "${encrypted_file_path}")"
 
-    if ! driver_decrypt_file "yaml" "${encrypted_file_path}" "${encrypted_file_dec}"; then
+    if ! driver_decrypt_file "${encrypted_type}" "${encrypted_file_path}" "${encrypted_file_dec}"; then
         rm -rf "${encrypted_file_dec}"
         fatal 'Error while decrypting file: %s' "${file}"
     fi


### PR DESCRIPTION
… when running helm secrets

**What this PR does / why we need it**:
adds flag --sopsjson. <file.json>
Allows the wrapper to also decrypt json files.
Usage: Json config file that is not parameterized with helm values, that needs to go into a k8s secret.
e.g. chart/files/configs/config_sensitive.json
In the tempate/secrets.yaml we then .Files.get config_sensitive.json.dec

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
#249 

**Special notes for your reviewer**:
Works similar to --values (Tried to share the code)
main difference is that it does not add the --sopsjson <file.json> to the command line that is passed to helm.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ./ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
