### PR TITLE
fix YAML detection for Windows line-endings (#290)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- fixes detection of SOPS YAML files with Windows line-endings (CR LF)
+
 ## [4.2.0] - 2022-11-08
 ### Added
 - `--ignore-missing-values` (`HELM_SECRETS_IGNORE_MISSING_VALUES`). This option allows ignoring errors related to file not found.

--- a/scripts/backends/sops.sh
+++ b/scripts/backends/sops.sh
@@ -84,7 +84,7 @@ _sops_winpath() {
 }
 
 _sops_dec_get_type() {
-    if grep -Fxq 'sops:' "${1}"; then
+    if grep -xq 'sops:\s*' "${1}"; then
         echo 'yaml'
     elif grep -q '"data": "ENC' "${1}"; then
         echo 'binary'

--- a/tests/assets/values/sops/.gitattributes
+++ b/tests/assets/values/sops/.gitattributes
@@ -1,0 +1,1 @@
+some-secrets.windows.yaml text eol=crlf

--- a/tests/assets/values/sops/some-secrets.windows.yaml
+++ b/tests/assets/values/sops/some-secrets.windows.yaml
@@ -1,0 +1,30 @@
+global_secret: ENC[AES256_GCM,data:rBe1YaFx5B/gkQ==,iv:RJmb3MBk4X8Rk8VXh/zmzfTMnE4EIaSEbSzUXvLmtlk=,tag:YjB+F2taqPGi/52B730YoQ==,type:str]
+key: ENC[AES256_GCM,data:x8QQ2xAnLaqJ0W1i0Mqht/xuaqK3vWxa+tbRxWUj64iTQCKOVUHXiln+SDZ1yKArGgQCL9FkNztFdHCUheoDEjmbr/AHFRNrHlf2LmcOcuWlXXlOnuZWQPOMK2qFLjCfNYIAevPdF55AhWDr1iGq9W1/Sub7wDMzl3YpOz8E0Rv4lKCZ2DIx2vnXOxZXgtBLm0ZjkVpmJqd6H9iipAhzBt4TkH8siY2MytX7J4QA6ipbvKIX/pgevz9qG3SApsy1AYKvj2/4Yxbx8iZ9S21H2n7of6KfymBfM3lqKbVqONhGv7epHJW7gDDG21Xr11DYHHnSmxrdk3ZpEAy9QfncSwU4cDyu8XB99eRk180n5p2G4KDvTLd5CMS5FpURegJce+h5d3gR6y+vW7ZqsM55FXuNTZACe6/9i5+MrTliCoQiJaaPej9p4MIEapp0+VkbbIBZTnYxIsgn9PUQ6iKvm35cCU0kEVkpBOPMvTiielnywkJiDku/6/pNl1wIPjqaqiMA0lvNDGDHxdFifpoEJ7LOutOF9ofXHC7ylzHEFu2m7y1xSOcP58Ls7G2OPEW7E8CfN9s6CS2vCycNP3AMxoQC7/dncIzaKuXs8RApP0A/rXjjsOePj816JIXCUWKtTgLKmY8MB9ic9mejNTS+6Gn7LBylzpc7odzmdr1MlwHk7gtUrF+HCBuehiBKiiePEhMTJj7UppEw3BaH4CydHMJ+5Wp7oh5ycXys4HsFn0hE3gZJZe/hWZsRj/Uz/kuAcYUwfCCl51sNMzh8MV1R0bc3juhaeJ8MffZHwHcRemrNMbaHUyhayFneDsceA7+QxdlJnCVYH2EWQjMeLWg+6Wx0M/YBMfZy/biSfih4Qiu1bLYxYOpLyIRnk6RcSvqvnCc3CgHpvu0JeUabFa8FmzIgF3B2FXyh38e6nE5rOU1oyiLIBZCzhJlp6Xgzn5s7uMzdiZ4Q6eqGhyaxF1SdUEhavnS7bR4kxP8bI/2adg1TE1veqd27/hM0eTepd9hrq0GYTpHjA8rmSautSNaXFSvwr+0+8wEamC7DQgqV75X/XXzJQMKiOE8huO2hGFXYYvJVZ7cH/irTkgXUwMUORolrVBT2T/nv6kPx0xKm7CGh7JubFO2j8ls/QKwFQn/VZn+SZUFUgl7D/pyRq/XmSGJaDlimeEch3WbpfYOQ/MF0Iq4+JB5IkMJGK6glLw==,iv:pAIO+Nc5V8g3K5wpUdYaMlmpuSHoV89JiqRQOrNjNC0=,tag:8gqcGNeb72sMq5mxUaQusQ==,type:str]
+service:
+    port: ENC[AES256_GCM,data:U1o=,iv:YHGc2JAlX0kOY4yocm0sQKr5gCRwZgamEhaIS3HoiJ8=,tag:fEukYoQDZHDB9tu8xwyFJQ==,type:int]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2021-07-13T09:38:36Z"
+    mac: ENC[AES256_GCM,data:V6JiJ6YApYN5fsElJ2sBhaWJX1XGN/e+0qQFIcoIzdLZg/vnAc0vbqLYmXv69onKPeNrdfs/rjhoR1fY/urCGaPFFrx7k6kFFc1eyB5B3+ZT8RUhTa+Y/RdpzyfrVEBht6Iiu3iqm2P35mRjTKTkm5pUE1YmgfGx9p5hsb3hVKY=,iv:gfMmYjBfuf/gcaZqXtf/pjHNK+G7KkIY8CK6LTflWHU=,tag:+JznqzEBq67b4/WKOri00Q==,type:str]
+    pgp:
+        - created_at: "2021-07-13T09:38:36Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMA9ce5qCwOO4MAQf/cpWRY9XHCN3YS7eThaGCWhQfP/S0xvlo39xKcfQxNlJC
+            mYpy3TYnvVMk0BZ1+i2hXcuudcrsp60xewuTjBasA8gvx19xtD5YAy38FtZuAawe
+            R611Dzt3SCGz/WPfd1uGxVC3xru3q6efHXFdBsvf8bMIymjnPDGDKyXbEr5/auXj
+            HKsc/0ohIt+Uz107boq3c00o1M9Jif/aTwhZUQZnn8i3aPEhTDxOR/CEKqLMngUt
+            3jvd73iigkhK8ZJJnBudS8hekJhP94bOI0X8e6ngOstTiqE7jyZRnJH0dia4lEDN
+            sqANAAhBYfzVTWPuZ6qSJ6EJGEKci4uB/gcz29dcVNJeATTtSie6oYE64V9ZqAMA
+            /3FX6rYcYn9MbzZQQrWkRpuOaarzXx+Dxv/2BXAVAN3Pibo9qk/VaPEMA7MT/PGt
+            A2ZEIM2tC2Np0MexLoqzVENbtpNA4z+fXFm3p9Uv2A==
+            =hUbO
+            -----END PGP MESSAGE-----
+          fp: D6174A02027050E59C711075B430C4E58E2BBBA3
+    encrypted_regex: ^.+$
+    version: 3.7.1

--- a/tests/unit/decrypt.bats
+++ b/tests/unit/decrypt.bats
@@ -68,6 +68,19 @@ load '../bats/extensions/bats-file/load'
     assert_success
 }
 
+@test "decrypt: Decrypt some-secrets.windows.yaml" {
+    if ! is_backend "sops"; then
+        skip
+    fi
+
+    VALUES="assets/values/${HELM_SECRETS_BACKEND}/some-secrets.windows.yaml"
+    VALUES_PATH="${TEST_TEMP_DIR}/${VALUES}"
+
+    run "${HELM_BIN}" secrets decrypt "${VALUES_PATH}"
+    assert_output --partial 'global_secret: global_bar'
+    assert_success
+}
+
 @test "decrypt: Decrypt values.yaml" {
     VALUES="assets/values/${HELM_SECRETS_BACKEND}/values.yaml"
     VALUES_PATH="${TEST_TEMP_DIR}/${VALUES}"


### PR DESCRIPTION
Signed-off-by: Marco Poli <marco.a.poli@gmail.com>

**What this PR does / why we need it**: fixes detection of SOPS YAML files with Windows line-endings (CR LF)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #290 

**Special notes for your reviewer**: the .gitattributes is there to prevent that one specific YAML file from having its line-endings automatically converted.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
