### PR TITLE
fix output to handle error when using --evaluate-templates

### DIFF
--- a/scripts/backends/vals.sh
+++ b/scripts/backends/vals.sh
@@ -12,8 +12,9 @@ _vals() {
     # https://github.com/variantdev/vals/issues/60
     # Store stderr in a var - https://stackoverflow.com/a/52587939
     if ! { error=$({ $_VALS "$@" 1>&3; } 2>&1); } 3>&1; then
-        echo 'vals error:'
-        echo "$error"
+        echo 'vals error:' >&2
+        echo "$error" >&2
+        exit 1
     fi
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
fix output and exit the process in case of templating error when using `--evaluate-templates` flag

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
it fixes the situation when some Vals backend is unavailable or any issue with resolving secrets. before PR these errors were ignored and be written in templated files that leads to strange errors when Helm tries to apply these files to K8s

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
