### PR TITLE
Fix curl arguments (#342

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Migrations for ArgoCD multi source application limitations
 
+### Fixed
+- Error `curl: option --netrc-file=/custom-tools/.netrc: is unknown`, if NETRC environment variable is defined
+
 ## [4.3.0] - 2023-02-18
 ### Added
 - Support for evaluating secret references (`--evaluate-templates`; `vals` backend) in helm templates (requires helm 3.9.0; vals 0.20+)

--- a/scripts/lib/http.sh
+++ b/scripts/lib/http.sh
@@ -4,7 +4,7 @@ set -euf
 
 download() {
     if command -v "${HELM_SECRETS_CURL_PATH:-curl}" >/dev/null; then
-        "${HELM_SECRETS_CURL_PATH:-curl}" ${NETRC:+--netrc-file="${NETRC}"} -sSfL "$1"
+        "${HELM_SECRETS_CURL_PATH:-curl}" ${NETRC:+--netrc-file "${NETRC}"} -sSfL "$1"
     elif command -v "${HELM_SECRETS_WGET_PATH:-wget}" >/dev/null; then
         "${HELM_SECRETS_WGET_PATH:-wget}" -q -O- "$1"
     else


### PR DESCRIPTION
The equal sign in the curl arguments is superfluous.

**What this PR does / why we need it**:
It fixes an error:  
`curl: option --netrc-file=/custom-tools/.netrc: is unknown`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
