### PR TITLE
Add the 1Password CLI as a custom backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added a new custom backend for the 1Password CLI, which is located at `examples/backends/onepassword.sh` (#431)
+
 ## [4.5.1] - 2023-09-23
 
 ### Added

--- a/docs/Secret Backends.md
+++ b/docs/Secret Backends.md
@@ -28,7 +28,7 @@ For more information, read [USAGE.md](./Usage.md#override-backend-per-value-file
 
 ## Implement an own secret backend
 
-Start by a copy of [sops backend](https://github.com/jkroepke/helm-secrets/blob/main/scripts/backends/sops.sh) and adjust to your own needs.
+Start by a copy of [sops backend](https://github.com/jkroepke/helm-secrets/blob/main/scripts/lib/backends/sops.sh) and adjust to your own needs.
 The custom backend can be load via `HELM_SECRETS_BACKEND` parameter or `-d` option (higher preference).
 
 ## Pass additional arguments to a secret backend

--- a/examples/backends/onepassword.sh
+++ b/examples/backends/onepassword.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env sh
+
+#
+# The 1Password CLI (https://developer.1password.com/docs/cli) allows you to get secrets
+# from your vaults using secret references (https://developer.1password.com/docs/cli/secrets-reference-syntax).
+# Secrets can be referenced in configuration files as described
+# by the template syntax documentation (https://developer.1password.com/docs/cli/secrets-template-syntax).
+#
+# To use this secret backend, you need to install the 1Password CLI and sign in:
+# https://developer.1password.com/docs/cli/get-started
+#
+
+set -euf
+
+_ONEPASSWORD="${HELM_SECRETS_ONEPASSWORD_PATH:-op}"
+
+# shellcheck disable=SC2034
+# https://developer.1password.com/docs/cli/secrets-reference-syntax/#syntax-rules
+_BACKEND_REGEX='op://[A-Za-z0-9\-_./ ]*'
+
+# shellcheck source=scripts/lib/backends/_custom.sh
+. "${SCRIPT_DIR}/lib/backends/_custom.sh"
+
+_onepassword() {
+    # shellcheck disable=SC2086
+    set -- ${SECRET_BACKEND_ARGS} "$@"
+    eval "$($_ONEPASSWORD signin)"
+    $_ONEPASSWORD "$@"
+}
+
+_custom_backend_get_secret() {
+    if [ $# -eq 1 ]; then
+        _SECRET=$1
+    else
+        _SECRET=$2
+    fi
+
+    _onepassword read --force "${_SECRET}"
+}
+
+_custom_backend_decrypt_file() {
+    input="${2}"
+    # if omit then output to stdout
+    output="${3:-}"
+
+    # Templates supported by `op inject`:
+    # https://developer.1password.com/docs/cli/secrets-template-syntax
+
+    if [ "${output}" = "" ]; then
+        _onepassword inject --force --in-file "${input}"
+    else
+        _onepassword inject --force --in-file "${input}" --out-file "${output}"
+    fi
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -64,6 +64,27 @@ Alternately available via [homebrew](https://brew.sh/):
 brew info vault
 ```
 
+### onepassword (optional)
+
+The 1Password CLI is only required to run the tests with the `HELM_SECRETS_BACKEND=custom-onepassword` environment variable.
+
+Instructions on how to install and set up the 1Password CLI can be found here: https://developer.1password.com/docs/cli/get-started
+
+Create the following test item before running the tests:
+
+```shell
+op item create --category=login \
+    --title='helm-secrets test' \
+    --vault='Private' \
+    'username=test-username' \
+    'password=mytestpassword123' \
+    'email[email]=test@example.com' \
+    'data.username[text]=a-test-name' \
+    'data.password[password]=testthispassword' \
+    'data 2.email[email]=my-test@example.com' \
+    'data 2.password[password]=my-test-could-be-different!'
+```
+
 ## Run
 
 If possible start the tests from the root of the repository. Then execute:

--- a/tests/assets/values/custom-backend/onepassword-secrets.yaml
+++ b/tests/assets/values/custom-backend/onepassword-secrets.yaml
@@ -1,0 +1,11 @@
+service:
+  username: op://Private/helm-secrets test/username
+  password: op://Private/helm-secrets test/password
+data:
+  owner: op://Private/helm-secrets test/email
+  names:
+    - op://Private/helm-secrets test/data/username
+    - op://Private/helm-secrets test/data 2/email
+  passwords:
+    - op://Private/helm-secrets test/data/password
+    - op://Private/helm-secrets test/data 2/password

--- a/tests/lib/helper.bash
+++ b/tests/lib/helper.bash
@@ -46,6 +46,10 @@ is_backend() {
     [[ "${HELM_SECRETS_BACKEND}" == "${1}" ]]
 }
 
+is_custom_backend() {
+    [[ "${HELM_SECRETS_CUSTOM_BACKEND}" == "custom-${1}" ]]
+}
+
 on_windows() {
     # shellcheck disable=SC2154
     ! [[ "${_uname}" == "Darwin" || "${_uname}" == "Linux" ]] || on_wsl

--- a/tests/lib/setup_suite.bash
+++ b/tests/lib/setup_suite.bash
@@ -5,13 +5,13 @@ load '../lib/binaries'
 
 setup_suite() {
     {
+        export HELM_SECRETS_BACKEND="${HELM_SECRETS_BACKEND:-"sops"}"
+        export HELM_SECRETS_CUSTOM_BACKEND=${HELM_SECRETS_CUSTOM_BACKEND:-""}
+
         if [[ "${HELM_SECRETS_BACKEND}" == "custom-"* ]]; then
             HELM_SECRETS_CUSTOM_BACKEND="${HELM_SECRETS_BACKEND}"
             unset HELM_SECRETS_BACKEND
         fi
-
-        export HELM_SECRETS_BACKEND="${HELM_SECRETS_BACKEND:-"sops"}"
-        export HELM_SECRETS_CUSTOM_BACKEND=${HELM_SECRETS_CUSTOM_BACKEND:-""}
 
         REAL_HOME="${HOME}"
         export HOME="${BATS_SUITE_TMPDIR}"

--- a/tests/lib/setup_suite.bash
+++ b/tests/lib/setup_suite.bash
@@ -5,7 +5,13 @@ load '../lib/binaries'
 
 setup_suite() {
     {
+        if [[ "${HELM_SECRETS_BACKEND}" == "custom-"* ]]; then
+            HELM_SECRETS_CUSTOM_BACKEND="${HELM_SECRETS_BACKEND}"
+            unset HELM_SECRETS_BACKEND
+        fi
+
         export HELM_SECRETS_BACKEND="${HELM_SECRETS_BACKEND:-"sops"}"
+        export HELM_SECRETS_CUSTOM_BACKEND=${HELM_SECRETS_CUSTOM_BACKEND:-""}
 
         REAL_HOME="${HOME}"
         export HOME="${BATS_SUITE_TMPDIR}"

--- a/tests/unit/secret-backends.bats
+++ b/tests/unit/secret-backends.bats
@@ -116,3 +116,37 @@ load '../bats/extensions/bats-file/load'
     assert_output --partial 'production#global_secret'
     assert_success
 }
+
+@test "secret-backend: helm secrets --backend ${GIT_ROOT}/examples/backends/onepassword.sh" {
+    if ! is_custom_backend "onepassword"; then
+        skip
+    fi
+
+    FILE="${TEST_TEMP_DIR}/assets/values/custom-backend/onepassword-secrets.yaml"
+
+    run "${HELM_BIN}" secrets --backend "${GIT_ROOT}/examples/backends/onepassword.sh" decrypt "${FILE}"
+
+    refute_output --partial 'op://'
+    assert_output --partial 'test-username'
+    assert_output --partial 'mytestpassword123'
+    assert_output --partial 'a-test-name'
+    assert_output --partial 'my-test@example.com'
+    assert_success
+}
+
+@test "secret-backend: helm secrets + env HELM_SECRETS_BACKEND=${GIT_ROOT}/examples/backends/onepassword.sh" {
+    if ! is_custom_backend "onepassword"; then
+        skip
+    fi
+
+    FILE="${TEST_TEMP_DIR}/assets/values/custom-backend/onepassword-secrets.yaml"
+
+    run env HELM_SECRETS_BACKEND="${GIT_ROOT}/examples/backends/onepassword.sh" WSLENV="HELM_SECRETS_BACKEND:${WSLENV}" "${HELM_BIN}" secrets decrypt "${FILE}"
+
+    refute_output --partial 'op://'
+    assert_output --partial 'test-username'
+    assert_output --partial 'mytestpassword123'
+    assert_output --partial 'a-test-name'
+    assert_output --partial 'my-test@example.com'
+    assert_success
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the 1Password CLI as an additional custom backend.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #424

**Special notes for your reviewer**:

I really wanted to make the tests work as well, but for some reason `op` always thinks it is not authenticated.
Manually running the decrypt function with the test file does work as expected.
I tried a few things to make this work with BATS:
- The configuration directory for op `~/.config/op` was copied to `${HOME}/.config/op` within `setup_suite.bash`
- Additionally I tried to add a session token via an exported env var or using the `--session` parameter of `op`
- Trying to authenticate `op` within `setup_suite.bash` doesn't work, since `op` reports it is not signed in during the test run anyway

If you don't have an idea on how to potentially fix this and don't want to keep some manual test instructions for this I'll remove that commit again.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
