### PR TITLE
Update ArgoCD Integration.md

### DIFF
--- a/docs/ArgoCD Integration.md
+++ b/docs/ArgoCD Integration.md
@@ -547,7 +547,6 @@ spec:
 
 # Known Limitations
 ## External Chart and local values
-Please note that it is not possible to use helm secrets in Argo CD for external Charts.
 Please take a look at [this issue](https://github.com/argoproj/argo-cd/issues/7257) for more information.
 
 As workaround, you can fetch additional values from remote locations:

--- a/docs/ArgoCD Integration.md
+++ b/docs/ArgoCD Integration.md
@@ -69,7 +69,7 @@ spec:
 Helm will call helm-secrets
 because it is [registered](https://github.com/jkroepke/helm-secrets/blob/4e61c556655b99e16d2faff5fd2312251ad06456/plugin.yaml#L12-L19) as [downloader plugin](https://helm.sh/docs/topics/plugins/#downloader-plugins).
 
-## Multi-Source Application Support [BETA]
+## Multi-Source Application Support
 
 ArgoCD has limited supported for helm-secrets and Multi-Source application.
 

--- a/docs/ArgoCD Integration.md
+++ b/docs/ArgoCD Integration.md
@@ -71,7 +71,7 @@ because it is [registered](https://github.com/jkroepke/helm-secrets/blob/4e61c55
 
 ## Multi-Source Application Support [BETA]
 
-ArgoCD has limited supported for helm-secrets and Multi-Source application. `sops` backend is not tested yet.
+ArgoCD has limited supported for helm-secrets and Multi-Source application.
 
 References:
 * https://github.com/argoproj/argo-cd/issues/11866


### PR DESCRIPTION
1. Update the doc since it is possible to use helm secrets in Argo CD for external Charts.
2. `sops` backend was tested & is working.

**What this PR does / why we need it**:
Update the doc since it is possible to use helm secrets in Argo CD for external Charts & the solution is in the same ArgoCD Integration.md [here](https://github.com/jkroepke/helm-secrets/blob/c6888bec3e0b96933b3ced1a7d8e6267ca4c5976/docs/ArgoCD%20Integration.md?plain=1#L114)