### PR TITLE
docs: update helm-git sample

### DIFF
--- a/docs/Values.md
+++ b/docs/Values.md
@@ -63,7 +63,7 @@ helm-secrets support [helm-git](https://github.com/aslafy-z/helm-git).
 With this combination, you can fetch secret from other git repositories.
 
 ```bash
-helm template -f secrets://git+https://[provider.com]/[user]/[repo]@[path/to/charts][?[ref=git-ref][&sparse=0][&depupdate=0]]
+helm template -f secrets://git+https://<provider.com>/<path/to/repo>[@path/to/charts][?[ref=git-ref][&sparse=0][&depupdate=0][&package=0]]
 ```
 
 Other plugins like [helm-s3, helm-gcs](https://helm.sh/docs/community/related/#helm-plugins) are supported as well.


### PR DESCRIPTION
`helm-git` path separator is now optional, correctly supports multi-level repo (GitLab style) and has the `package` option.