### PR TITLE
docs: update help for decrypt/encrypt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixes
+- fix: examples in the help of encrypt/decrypt commands
+
 ## [4.6.1] - 2024-08-09
 
 ### Fixes

--- a/scripts/commands/decrypt.sh
+++ b/scripts/commands/decrypt.sh
@@ -4,7 +4,7 @@ set -euf
 
 dec_usage() {
     cat <<EOF
-helm secrets [ OPTIONS ] dec [ -i ] [ --terraform ] <path to file>
+helm secrets [ OPTIONS ] decrypt [ -i ] [ --terraform ] <path to file>
 
 Decrypt secrets
 
@@ -13,11 +13,11 @@ It uses your gpg credentials to decrypt previously encrypted values file.
 You can use plain sops to decrypt specific files - https://github.com/getsops/sops
 
 Typical usage:
-  $ helm secrets dec secrets/project/secrets.yaml
+  $ helm secrets decrypt secrets/project/secrets.yaml
 
   # Decrypt file inline
 
-  $ helm secrets dec -i secrets/project/secrets.yaml
+  $ helm secrets decrypt -i secrets/project/secrets.yaml
 
 EOF
 }

--- a/scripts/commands/encrypt.sh
+++ b/scripts/commands/encrypt.sh
@@ -4,7 +4,7 @@ set -euf
 
 enc_usage() {
     cat <<EOF
-helm secrets [ OPTIONS ] enc [ -i ] <path to file>
+helm secrets [ OPTIONS ] encrypt [ -i ] <path to file>
 
 Encrypt secrets
 
@@ -15,7 +15,7 @@ This allows you to first decrypt the file, edit it, then encrypt it again.
 You can use plain sops to encrypt - https://github.com/getsops/sops
 
 Example:
-  $ helm secrets enc <SECRET_FILE_PATH>
+  $ helm secrets encrypt <SECRET_FILE_PATH>
   $ git add <SECRET_FILE_PATH>
   $ git commit
   $ git push


### PR DESCRIPTION
**What this PR does / why we need it**:

Minor change in the example of `decrypt` / `encrypt` commands. The examples still used `dec` and `enc` from version 3.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
