### PR TITLE
Drops xargs from runtime dependencies

### DIFF
--- a/scripts/commands/helm.sh
+++ b/scripts/commands/helm.sh
@@ -29,7 +29,7 @@ decrypted_file_list=$(_mktemp)
 _trap_hook() {
     if [ -s "${decrypted_file_list}" ]; then
         while read -r f; do
-            rm "$f"
+            rm "$f" || continue
             if [ "${QUIET}" = "false" ]; then
                 printf "[helm-secrets] Removed: %s\n" "$f"
             fi
@@ -208,7 +208,10 @@ helm_wrapper() {
                     fi
                 else
                     if decrypt_helper "${real_file}" "${sops_type}"; then
-                        printf '%s\0' "${file_dec}" >>"${decrypted_file_list}"
+                        # printf '%s\0' "${file_dec}" >>"${decrypted_file_list}"
+                        # ^^ ... I'm sure there was a good reason for this ...
+                        # let's see where CI breaks ... when I just go with the obvious:
+                        echo "${file_dec}" >>"${decrypted_file_list}"
 
                         if [ "${QUIET}" = "false" ]; then
                             log 'Decrypt: %s' "${file}"

--- a/scripts/commands/helm.sh
+++ b/scripts/commands/helm.sh
@@ -32,7 +32,7 @@ _trap_hook() {
         _idx=1
         while test "$_idx" -lt "$_max"; do
             f="$(awk "BEGIN{FS=\"\x00\"}{print \$$_idx}" "${decrypted_file_list}")"
-            _idx=$((_idx+1))
+            _idx=$((_idx + 1))
             rm "$f" || continue
             if [ "${QUIET}" = "false" ]; then
                 printf "[helm-secrets] Removed: %s\n" "$f"

--- a/scripts/commands/helm.sh
+++ b/scripts/commands/helm.sh
@@ -30,8 +30,7 @@ _trap_hook() {
     if [ -s "${decrypted_file_list}" ]; then
         _max="$(awk "BEGIN{FS=\"\x00\"}{}END{print NF}" "${decrypted_file_list}")"
         _idx=1
-        while test "$_idx" -lt "$_max"
-        do
+        while test "$_idx" -lt "$_max"; do
             f="$(awk "BEGIN{FS=\"\x00\"}{print \$$_idx}" "${decrypted_file_list}")"
             rm "$f" || continue
             if [ "${QUIET}" = "false" ]; then

--- a/scripts/commands/helm.sh
+++ b/scripts/commands/helm.sh
@@ -32,7 +32,7 @@ _trap_hook() {
         _idx=1
         while test "$_idx" -lt "$_max"; do
             f="$(awk "BEGIN{FS=\"\x00\"}{print \$$_idx}" "${decrypted_file_list}")"
-            _idx="$(expr "$_idx" + 1)"
+            _idx=$((_idx+1))
             rm "$f" || continue
             if [ "${QUIET}" = "false" ]; then
                 printf "[helm-secrets] Removed: %s\n" "$f"

--- a/scripts/commands/helm.sh
+++ b/scripts/commands/helm.sh
@@ -28,8 +28,7 @@ decrypted_file_list=$(_mktemp)
 
 _trap_hook() {
     if [ -s "${decrypted_file_list}" ]; then
-        while read -r f
-        do
+        while read -r f; do
             rm "$f"
             if [ "${QUIET}" = "false" ]; then
                 printf "[helm-secrets] Removed: %s\n" "$f"

--- a/scripts/commands/helm.sh
+++ b/scripts/commands/helm.sh
@@ -32,14 +32,11 @@ _trap_hook() {
         _idx=1
         while test "$_idx" -lt "$_max"; do
             f="$(awk "BEGIN{FS=\"\x00\"}{print \$$_idx}" "${decrypted_file_list}")"
+            _idx="$(expr "$_idx" + 1)"
             rm "$f" || continue
             if [ "${QUIET}" = "false" ]; then
                 printf "[helm-secrets] Removed: %s\n" "$f"
             fi
-            # shellcheck won't like that one ...
-            # but can we _idx=$((_idx+1)) here / what would other tests say?
-            # ... I'm already banking a lot on awk ... maybe next try ...
-            _idx="$(expr "$_idx" + 1)"
         done >&2
 
         rm "${decrypted_file_list}"

--- a/scripts/commands/helm.sh
+++ b/scripts/commands/helm.sh
@@ -33,7 +33,7 @@ _trap_hook() {
             if [ "${QUIET}" = "false" ]; then
                 printf "[helm-secrets] Removed: %s\n" "$f"
             fi
-        done <"${decrypted_file_list}"
+        done <"${decrypted_file_list}" >&2
 
         rm "${decrypted_file_list}"
     fi

--- a/scripts/commands/helm.sh
+++ b/scripts/commands/helm.sh
@@ -28,13 +28,13 @@ decrypted_file_list=$(_mktemp)
 
 _trap_hook() {
     if [ -s "${decrypted_file_list}" ]; then
-        if [ "${QUIET}" = "false" ]; then
-            echo >&2
-            # shellcheck disable=SC2016
-            xargs -0 -n1 sh -c 'rm "$1" && printf "[helm-secrets] Removed: %s\n" "$1"' sh >&2 <"${decrypted_file_list}"
-        else
-            xargs -0 rm >&2 <"${decrypted_file_list}"
-        fi
+        while read -r f
+        do
+            rm "$f"
+            if [ "${QUIET}" = "false" ]; then
+                printf "[helm-secrets] Removed: %s\n" "$f"
+            fi
+        done <"${decrypted_file_list}"
 
         rm "${decrypted_file_list}"
     fi


### PR DESCRIPTION
<!--
If you are using helm-secrets in your company or organization, we would like to invite you to add your information to this file.
https://github.com/jkroepke/helm-secrets/blob/main/USERS.md  
-->

**What this PR does / why we need it**:

As observed, integrating helm-secrets with OpenShift GitOpS / ArgoCD.
Following instructions, injecting helm-secrets plugin into Argo's repo-server, as per:
https://github.com/jkroepke/helm-secrets/wiki/ArgoCD-Integration#option-2-init-container

ArgoCD repo-server images does not ship with xargs, in its runtime.
While this was not an issue in my initial tests, it came to my attention that when someone registers an Application, setting a value from some SSM Parameter, usin awsssm:// refs. Then we enter that trap, which fails. "xargs: no such file or directory".

To my understanding, we do not really need xargs here, do we?
Here's another way to do it. Works better in our context.
Would it make sense to include that fix upstream?

Otherwise open to suggestions ...


**Which issue this PR fixes** N/A did not file an issue.

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [X] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR

arguably: nothing to communicate on / no user-facing impact