### PR TITLE
fix helm_wrapper does not honor escaped commas in --set arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.6.3] - 2025-02-28
+
+### Fixes
+- helm_wrapper does not honor escaped commas in --set arguments
+
 ## [4.6.2] - 2024-10-13
 
 ### Fixes
@@ -331,7 +336,8 @@ Started a fork of https://github.com/zendesk/helm-secrets
 - Verbose output is now on stderr
 - Support all helm sub commands and plugins
 
-[Unreleased]: https://github.com/kroepke/helm-secrets/compare/v4.6.2...HEAD
+[Unreleased]: https://github.com/kroepke/helm-secrets/compare/v4.6.3...HEAD
+[4.6.3]: https://github.com/jkroepke/helm-secrets/compare/v4.6.2...v4.6.3
 [4.6.2]: https://github.com/jkroepke/helm-secrets/compare/v4.6.1...v4.6.2
 [4.6.1]: https://github.com/jkroepke/helm-secrets/compare/v4.6.0...v4.6.1
 [4.6.0]: https://github.com/jkroepke/helm-secrets/compare/v4.5.1...v4.6.0

--- a/scripts/commands/helm.sh
+++ b/scripts/commands/helm.sh
@@ -85,9 +85,9 @@ helm_wrapper() {
                 case "${literal}" in
                 *\\)
                     if [ "${_literal}" != "" ]; then
-                      _literal="${_literal},${literal}"
+                        _literal="${_literal},${literal}"
                     else
-                      _literal="${literal}"
+                        _literal="${literal}"
                     fi
                     continue
                     ;;


### PR DESCRIPTION
<!--
If you are using helm-secrets in your company or organization, we would like to invite you to add your information to this file.
https://github.com/jkroepke/helm-secrets/blob/main/USERS.md  
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
