### PR TITLE
fix(#530): move deprecated command to platformCommand section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [4.6.5] - 2025-05-20
+
+### Fixes
+- fix: Unable to install since helm 3.18.0 #530 (https://github.com/jkroepke/helm-secrets/pull/531)
+
 ## [4.6.4] - 2025-05-02
 
 ### Fixes

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -5,7 +5,10 @@ description: |-
   This plugin provides secrets values encryption for Helm charts secure storing
 useTunnel: false
 platformCommand:
-  - command: "$HELM_PLUGIN_DIR/scripts/run.sh"
+  - os: linux
+    command: "$HELM_PLUGIN_DIR/scripts/run.sh"
+  - os: darwin
+    command: "$HELM_PLUGIN_DIR/scripts/run.sh"
   - os: windows
     command: >-
       cmd /c $HELM_PLUGIN_DIR\scripts\wrapper\run.cmd

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -4,8 +4,8 @@ usage: "Secrets encryption in Helm for Git storing"
 description: |-
   This plugin provides secrets values encryption for Helm charts secure storing
 useTunnel: false
-command: "$HELM_PLUGIN_DIR/scripts/run.sh"
 platformCommand:
+  - command: "$HELM_PLUGIN_DIR/scripts/run.sh"
   - os: windows
     command: >-
       cmd /c $HELM_PLUGIN_DIR\scripts\wrapper\run.cmd


### PR DESCRIPTION
**What this PR does / why we need it**:

The plugin.yaml does not accept the deprecated command key anymore since helm v3.18.0
See docs: [helm plugin](https://helm.sh/docs/topics/plugins/#the-pluginyaml-file)

**Which issue this PR fixes**:
fixes #530 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
