### PR TITLE
fix(#569): Change WSL to use Ubuntu distro instead of Debian

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -169,6 +169,7 @@ jobs:
         if: "contains(matrix.shell, 'wsl')"
         uses: Vampire/setup-wsl@6a8db447be7ed35f2f499c02c6e60ff77ef11278 # v6.0.0
         with:
+          distribution: Ubuntu-24.04
           wsl-version: 1
 
       - name: Setup coreutils


### PR DESCRIPTION
<!--
If you are using helm-secrets in your company or organization, we would like to invite you to add your information to this file.
https://github.com/jkroepke/helm-secrets/blob/main/USERS.md  
-->

**What this PR does / why we need it**:
The WSL tests in GitHub actions fail due to an outdated repository URL in the Debian distribution setup. Switching to an Ubuntu distribution fixes the issue.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:
fixes #569 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
