### PR TITLE
fix: handle trailing newlines correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixes
+- fix: preserve semantically relevant trailing newlines in decrypted data
+
 ## [4.6.10] - 2025-09-07
 
 ### Fixes

--- a/scripts/commands/decrypt.sh
+++ b/scripts/commands/decrypt.sh
@@ -91,9 +91,14 @@ decrypt() {
         fatal 'File does not exist: %s' "${filepath}"
     fi
 
-    if ! content=$(decrypt_helper "${encrypted_filepath}" "auto" "${output}"); then
+    # Append an underscore to the end of the content to prevent the stripping of trailing newlines
+    # occurring during command substitution.
+    if ! content=$(decrypt_helper "${encrypted_filepath}" "auto" "${output}" && printf '_'); then
         fatal 'File is not encrypted: %s' "${encrypted_filepath}"
     fi
+
+    # Remove the underscore again.
+    content="${content%_}"
 
     if [ "${terraform}" = "true" ]; then
         printf '{"content_base64":"%s"}' "$(printf '%s' "${content}" | base64 | tr -d \\n)"


### PR DESCRIPTION
This commit fixes a bug in the handling of trailing newlines. Previously, the following command sequence would result in a file without trailing newlines:

```
printf "abc: |+\n    multi\n    line\n\n\n" > test.yaml
sops encrypt --pgp <key> --input-type yaml test.yaml > test.secret
helm secrets decrypt test.secret
```

However, as the trailing newlines do belong to the multi-line string, this is semantically incorrect. This change preserves trailing newlines.

The issue originates from trailing newlines being deleted during Bash command substitution, cf. https://www.gnu.org/software/bash/manual/html_node/Command-Substitution.html.