### PR TITLE
Update Dockerfile in ArgoCD Integration.md

### DIFF
--- a/docs/ArgoCD Integration.md
+++ b/docs/ArgoCD Integration.md
@@ -184,7 +184,7 @@ SHELL ["bash", "-c"]
 RUN set -exuo pipefail \ 
     && export CURL_ARCH=$(uname -m | sed -e 's/x86_64/amd64/') \
     && wget -qO "${HELM_SECRETS_CURL_PATH}" "https://github.com/moparisthebest/static-curl/releases/latest/download/curl-${CURL_ARCH}" \
-    && export GO_ARCH=$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')
+    && export GO_ARCH=$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/') \
     && wget -qO "${HELM_SECRETS_KUBECTL_PATH}" "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${GO_ARCH}/kubectl" \
     && wget -qO "${HELM_SECRETS_SOPS_PATH}" "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.${GO_ARCH}" \
     && wget -qO- "https://github.com/helmfile/vals/releases/download/v${VALS_VERSION}/vals_${VALS_VERSION}_linux_${GO_ARCH}.tar.gz" | tar zxv -C "${HELM_SECRETS_VALS_PATH%/*}" vals \
@@ -198,7 +198,7 @@ RUN set -exuo pipefail \
         "${HELM_SECRETS_AGE_PATH}" \
     && ln -sf "${HELM_PLUGINS}/helm-secrets/scripts/wrapper/helm.sh" /usr/local/sbin/helm
 
-USER argocd
+USER $ARGOCD_USER_ID
 ```
 
 </details>


### PR DESCRIPTION
<!--
If you are using helm-secrets in your company or organization, we would like to invite you to add your information to this file.
https://github.com/jkroepke/helm-secrets/blob/main/USERS.md  
-->

**What this PR does / why we need it**:
This PR fixes two issues:

* Adds the missing slash.
* Sets the container user to the numeric $ARGOCD_USER_ID(`999`) so that Kubernetes can correctly validate `runAsNonRoot: true`.

The Argo CD image creates and runs the `argocd` user with UID `999`:

https://github.com/argoproj/argo-cd/blob/master/Dockerfile#L44

Kubernetes requires a non-zero numeric user ID to reliably verify that a container does not run as root:

https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kuberuntime/kuberuntime_container.go#L354


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

No related issue.

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [X] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
